### PR TITLE
Basic Input for Redux-Form

### DIFF
--- a/src/components/forms/input/inputComponent.js
+++ b/src/components/forms/input/inputComponent.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+/**
+ * Basic Input Component with Error and Warning display for redux-form 7
+ * Everything but 'styles' comes from `<Field/>` in redux-form 7.
+ * 
+ * @param {any} {
+ *   input,
+ *   label,
+ *   type,
+ *   disabled,
+ *   meta: { touched, error, warning },
+ *   styles
+ * } 
+ * @returns 
+ */
+function Input ({
+  input,
+  label,
+  type,
+  disabled,
+  meta: { touched, error, warning },
+  styles
+}) {
+  return (
+    <div>
+      <input {...input} disabled={disabled} placeholder={label} type={type} />
+      {touched &&
+        ((error && <div className={styles.error}>{error}</div>) ||
+          (warning && <div className={styles.warning}>{warning}</div>))}
+    </div>
+  )
+}
+
+Input.propTypes = {
+  styles: PropTypes.shape({
+    error: PropTypes.string
+    warning: PropTypes.string
+  })
+}
+
+export default Input


### PR DESCRIPTION
## Features
- Displays "Error" and "Warning" from meta prop on `Field` component.
- Allows you to pass a classname for each `error` and `warning` to style the text.

## Usage
__Prerequisites:__ Requires redux-form ^7.0.0 afaik

```js
<Field
  // All of the other normal props you'd pass to redux-form Field
  component={Input} />
```