### PR TITLE
ejection scripts

### DIFF
--- a/ejection-script.js
+++ b/ejection-script.js
@@ -1,0 +1,10 @@
+const path = require('path')
+const { execSync } = require('child_process')
+const args = require('minimist')(process.argv.slice(2))
+
+if (!args['sourceDir']) {
+    throw new Error('Please provide the relative source directory path of your project to eject Robits into, as: npm run eject-robits -- --sourceDir=./folder/')
+} else {
+    execSync('node ./node_modules/react-robits/merge-dependencies --sourceDir ' + args['sourceDir'] + ' && node ./node_modules/react-robits/pluck-components --sourceDir ' + args['sourceDir'] + ' && node ./node_modules/react-robits/update-references --sourceDir ' + args['sourceDir'] + ' && node ./node_modules/react-robits/erase-footprint --sourceDir ' + args['sourceDir'] + ' && npm uninstall react-robits -D -S && npm install', {stdio:[0,1,2]})
+    console.log('\n====================\nRobits ejection complete!\nThank you, come again :)\n')
+}

--- a/erase-footprint.js
+++ b/erase-footprint.js
@@ -1,0 +1,49 @@
+const path = require('path')
+const args = require('minimist')(process.argv.slice(2))
+const fs = require('fs')
+
+const projectPackageJSON = path.resolve(__dirname, '../../package.json')
+
+if (!args['sourceDir']) {
+    throw new Error('Please provide the relative source directory path of your project to eject Robits into, as: npm run eject-robits -- --sourceDir=./folder/')
+} else {
+    console.log('\nErasing the Robits footprint...\n--------------------\n')
+
+    var newFileData = ''
+
+    fs.readFile(projectPackageJSON, 'utf8', function (err, data) {
+        if (err) {
+          return console.log(err)
+        }
+
+        var linecount = 0
+        var lastRemovalIndex = 0
+
+        const lineReader = require('readline').createInterface({
+            input: fs.createReadStream(projectPackageJSON),
+            terminal: false
+        })
+
+        lineReader.on('line', function (line) {
+            linecount++
+            if (line.indexOf('robits') > -1) {
+                lastRemovalIndex = linecount
+                console.log('removing line: ', line)
+            } else {
+                if ((line.trim() === "}" || line.trim() === "},") && linecount - lastRemovalIndex === 1) {
+                    // robits was removed on last line, so need to chop off the trailing comma since the block ended
+                    newFileData = newFileData.substring(0, newFileData.length - 2)
+                    newFileData += '\n'
+                }
+                newFileData += line + '\n'
+            }
+            
+        }).on('close', function () {
+            fs.writeFile(projectPackageJSON, newFileData, 'utf8', err => {
+                if (err) return console.log(err)
+                console.log('Robits is now a ghost.\n\nUninstalling/Reinstalling packages...\n--------------------\n')
+            })
+        })
+
+    })    
+}

--- a/merge-dependencies.js
+++ b/merge-dependencies.js
@@ -1,0 +1,20 @@
+const mergePackages = require('@userfrosting/merge-package-dependencies')
+const path = require('path')
+const args = require('minimist')(process.argv.slice(2))
+
+if (!args['sourceDir']) {
+    throw new Error('Please provide the relative source directory path of your project to eject Robits into, as: npm run eject-robits -- --sourceDir=./folder/')
+} else {
+    console.log('Merging the Robits NPM package.json with your project package.json...\n--------------------\n')
+    // template has to be the parent project's package.json, so we don't wipe out anything there
+    const template = require(path.resolve(__dirname, '../../package.json'))
+
+    // designate parent project package json and this(robits) package.json 
+    let pkgPaths = [
+        path.resolve(__dirname, '../../package.json'),
+        path.resolve(__dirname, './package.json')
+    ]
+
+    // merge and save result to parent
+    mergePackages.npm(template, pkgPaths, path.resolve(__dirname, '../../package.json'), true);
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@storybook/addon-options": "^3.2.6",
     "@storybook/addons": "^3.2.6",
     "@storybook/react": "^3.2.8",
+    "@userfrosting/merge-package-dependencies": ">=1.2.0",
     "autoprefixer": "^7.2.5",
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.2.0",

--- a/pluck-components.js
+++ b/pluck-components.js
@@ -1,0 +1,11 @@
+const path = require('path')
+const { execSync } = require('child_process')
+const args = require('minimist')(process.argv.slice(2))
+
+if (!args['sourceDir']) {
+    throw new Error('Please provide the relative source directory path of your project to eject Robits into, as: npm run eject-robits -- --sourceDir=./folder/')
+} else {
+    console.log('\nCopying Robits from the NPM package and placing them at: "' + args['sourceDir'] + '" ...\n--------------------\n')
+    execSync('cp -r ./node_modules/react-robits/lib/ ' + args['sourceDir'] + 'robits && find ' + args['sourceDir'] + 'robits -mindepth 2 -type f -exec mv {} ' + args['sourceDir'] + 'robits' + ' \';\' && find ' + args['sourceDir'] + 'robits -mindepth 1 -type d -delete', {stdio:[0,1,2]})
+    console.log('All plucked.\n')
+}

--- a/update-references.js
+++ b/update-references.js
@@ -1,0 +1,74 @@
+const path = require('path')
+const args = require('minimist')(process.argv.slice(2))
+const fs = require('fs')
+
+function fromDir(startPath, filter, callback) {
+    const directory = path.resolve(__dirname, '../../' + startPath)
+
+    if (!fs.existsSync(directory)) {
+        console.log("Could not find directory:", directory)
+        return
+    }
+
+    var files = fs.readdirSync(directory)
+
+    for(var i=0; i < files.length; i++) {
+        var filename = path.join(startPath, files[i])
+        var stat = fs.lstatSync(filename)
+        if (stat.isDirectory()) {
+            if (filename.indexOf('robits') === -1) { // exclude our robits directory
+                fromDir(filename, filter, callback) //recurse
+            }
+        } else if (filter.test(filename)) {
+            callback(filename)
+        }
+    }
+}
+
+if (!args['sourceDir']) {
+    throw new Error('Please provide the relative source directory path of your project to eject Robits into, as: npm run eject-robits -- --sourceDir=./folder/')
+} else {
+    console.log('\nUpdating project references to Robits components...\n--------------------\n')
+    fromDir(args['sourceDir'], /\.js$/, filename => {
+
+        const lineReader = require('readline').createInterface({
+            input: fs.createReadStream(filename),
+            terminal: false
+        })
+          
+        lineReader.on('line', function (line) {
+            if (line.indexOf('react-robits') > -1) {
+                fs.readFile(filename, 'utf8', function (err, data) {
+                    if (err) {
+                      return console.log(err)
+                    }
+
+                    var result = data.replace(new RegExp(line, 'g'), (line) => {
+                        var retVal = ''
+                        var componentsString = line.substring(
+                            line.lastIndexOf('{') + 1, 
+                            line.lastIndexOf('}')
+                        )
+                        var components = componentsString.split(',')
+
+                        var relativePath = path.relative(path.dirname(filename), args['sourceDir'] + '/robits')
+
+                        for (var c = 0; c < components.length; c++) {
+                            var component = components[c].trim()
+                            console.log('-- updating reference for ' + component + ' in ' + filename)
+                            retVal += `import ${component} from '${relativePath}/${component}'\n`
+                        }
+
+                        return retVal
+                    })
+                  
+                    fs.writeFile(filename, result, 'utf8', err => {
+                       if (err) return console.log(err)
+                    })
+                })
+
+                lineReader.close()
+            }
+        })
+    })
+}


### PR DESCRIPTION
depends on: https://github.com/RobotsAndPencils/react-gantry/pull/40

developer runs `npm run eject-robits -- sourceDir=./folder/` within their gantry project. it should be run in order to break any linkage to R&P Robits, right before delivering the project source code to a client.

1. Merges Robits' package.json with project's package.json, comparing and resolving semvers
2. Copies the robits components into a `/robits/` folder within the supplied source directory
3. Updates references to robits components within project, so that they point to the files in the new `/robits/` directory instead of the npm package
4. Erases any line in the project package.json that has a reference to "robits"
5. Uninstalls the `react-robits` npm package, along with any of it's dependencies
6. Runs a fresh `npm install` since those dependencies are now a part of the project, per step 1

Note: as I write this, there is a nuance to step 3: it will only work if the `import { component, ... } from 'react-robits'` is written on a single line. I hope to enhance it down the road it so that a developer can format a long import as:
```
import {
   component1,
   component2,
...
} from 'react-robits'
```