### PR TITLE
Rename stylesheets away from theme

### DIFF
--- a/ejectionScripts/pluck-components.js
+++ b/ejectionScripts/pluck-components.js
@@ -247,11 +247,9 @@ updateReferences({
       projectUsesMagicTokens
     })
     if (args.shouldRemoveThemeWrapper === 'true') {
-      if (filepath.basename.includes(`_${args.themeName}`)) {
-        jetpack.rename(
-          filepath,
-          filepath.basename.replace(new RegExp(`_${args.themeName}`, 'g'), '')
-        )
+      const filename = path.basename(filepath)
+      if (filename.includes(`_${args.themeName}`)) {
+        jetpack.rename(filepath, filename.replace(new RegExp(`_${args.themeName}`, 'g'), ''))
       }
     }
   })

--- a/ejectionScripts/pluck-components.js
+++ b/ejectionScripts/pluck-components.js
@@ -62,7 +62,7 @@ const removeThemeWrapper = ({ filename, componentName, folderName }) => {
 
       const styling =
         (data.match(/styling(\[|\.)/g) || []).length > 0
-          ? `import styling from './${folderName}_${args.themeName}.module.scss'`
+          ? `import styling from './${folderName}.module.scss'`
           : ''
 
       data = data.replace(new RegExp("import ThemeWrapper from (.*)ThemeWrapper'", 'g'), styling)
@@ -246,6 +246,14 @@ updateReferences({
       filepath,
       projectUsesMagicTokens
     })
+    if (args.shouldRemoveThemeWrapper === 'true') {
+      if (filepath.basename.includes(`_${args.themeName}`)) {
+        jetpack.rename(
+          filepath,
+          filepath.basename.replace(new RegExp(`_${args.themeName}`, 'g'), '')
+        )
+      }
+    }
   })
 
   console.log('\x1b[32m%s\x1b[0m', 'Done.\n')


### PR DESCRIPTION
Removes the `_themeName` from the file name of .scss files during ejection if the user elected to remove the ThemeWrapper